### PR TITLE
Fix threshold for migration time property

### DIFF
--- a/src/ccs_scripts/aggregate/grid3d_migration_time.py
+++ b/src/ccs_scripts/aggregate/grid3d_migration_time.py
@@ -149,8 +149,8 @@ def migration_time_property_to_map(
         temp_file, temp_path = tempfile.mkstemp()
         os.close(temp_file)
         config_.input.properties = [
-            _config.Property(temp_path, None)
-        ]  # NBNB-AS: Input threshold?
+            _config.Property(temp_path, None, 0)
+        ]
         prop.to_file(temp_path)
     grid3d_aggregate_map.generate_from_config(config_)
     os.unlink(temp_path)

--- a/src/ccs_scripts/aggregate/grid3d_migration_time.py
+++ b/src/ccs_scripts/aggregate/grid3d_migration_time.py
@@ -148,9 +148,7 @@ def migration_time_property_to_map(
     for prop in t_prop.values():
         temp_file, temp_path = tempfile.mkstemp()
         os.close(temp_file)
-        config_.input.properties = [
-            _config.Property(temp_path, None, 0)
-        ]
+        config_.input.properties = [_config.Property(temp_path, None, 0)]
         prop.to_file(temp_path)
     grid3d_aggregate_map.generate_from_config(config_)
     os.unlink(temp_path)


### PR DESCRIPTION
Lower threshold for migration time property is set to 0. By default it was 1e-10, censoring migration time = 0.