### PR TITLE
Add test for weight-by-dz option

### DIFF
--- a/tests/test_aggregate_maps.py
+++ b/tests/test_aggregate_maps.py
@@ -1,7 +1,7 @@
 import os
 import shutil
-from pathlib import Path
 import tempfile
+from pathlib import Path
 
 import pytest
 import xtgeo
@@ -206,15 +206,15 @@ def test_aggregated_map8():
             str(result_y),
         ]
     )
-    
+
     # Run the exact same config but with weight_by_dz: no
     cfg_content = Path(cfg).read_text()
     cfg_content_no_weight = cfg_content.replace("weight_by_dz: yes", "weight_by_dz: no")
-    
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as tmp_cfg:
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as tmp_cfg:
         tmp_cfg.write(cfg_content_no_weight)
         tmp_cfg_path = tmp_cfg.name
-    
+
     try:
         # Run with weight_by_dz: no
         grid3d_aggregate_map.main(
@@ -227,16 +227,16 @@ def test_aggregated_map8():
                 str(result_n),
             ]
         )
-        
+
         # Compare results - maps with dz-weighting should have higher values
         surf_with_dz = xtgeo.surface_from_file(result_y / "all--sum_permx.gri")
         surf_without_dz = xtgeo.surface_from_file(result_n / "all--sum_permx.gri")
-        
+
         # Assert that dz-weighted values are higher than non-weighted
         assert surf_with_dz.values.mean() > surf_without_dz.values.mean()
         assert surf_with_dz.values.max() > surf_without_dz.values.max()
     finally:
         # Clean up temp file
         os.unlink(tmp_cfg_path)
-    
+
     shutil.rmtree(str(Path(result)))

--- a/tests/test_aggregate_maps.py
+++ b/tests/test_aggregate_maps.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from pathlib import Path
+import tempfile
 
 import pytest
 import xtgeo
@@ -178,4 +179,64 @@ def test_aggregated_map7():
             "all--max_sgstrand--25000101",
         ]
     )
+    shutil.rmtree(str(Path(result)))
+
+
+def test_aggregated_map8():
+    result = Path(__file__).absolute().parent / "aggregate8_folder"
+    if os.path.exists(result):
+        shutil.rmtree(str(Path(result)))
+
+    result_y = result / "weight-by-dz-yes"
+    result_n = result / "weight-by-dz-no"
+    result_y.mkdir(parents=True)
+    result_n.mkdir(parents=True)
+
+    cfg = "tests/yaml/config_aggregate8.yml"
+    assert "weight_by_dz: yes" in Path(cfg).read_text()
+
+    # Run with weight_by_dz: yes
+    grid3d_aggregate_map.main(
+        [
+            "--config_aggregate",
+            cfg,
+            "--mapfolder",
+            str(result_y),
+            "--plotfolder",
+            str(result_y),
+        ]
+    )
+    
+    # Run the exact same config but with weight_by_dz: no
+    cfg_content = Path(cfg).read_text()
+    cfg_content_no_weight = cfg_content.replace("weight_by_dz: yes", "weight_by_dz: no")
+    
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as tmp_cfg:
+        tmp_cfg.write(cfg_content_no_weight)
+        tmp_cfg_path = tmp_cfg.name
+    
+    try:
+        # Run with weight_by_dz: no
+        grid3d_aggregate_map.main(
+            [
+                "--config_aggregate",
+                tmp_cfg_path,
+                "--mapfolder",
+                str(result_n),
+                "--plotfolder",
+                str(result_n),
+            ]
+        )
+        
+        # Compare results - maps with dz-weighting should have higher values
+        surf_with_dz = xtgeo.surface_from_file(result_y / "all--sum_permx.gri")
+        surf_without_dz = xtgeo.surface_from_file(result_n / "all--sum_permx.gri")
+        
+        # Assert that dz-weighted values are higher than non-weighted
+        assert surf_with_dz.values.mean() > surf_without_dz.values.mean()
+        assert surf_with_dz.values.max() > surf_without_dz.values.max()
+    finally:
+        # Clean up temp file
+        os.unlink(tmp_cfg_path)
+    
     shutil.rmtree(str(Path(result)))

--- a/tests/yaml/config_aggregate8.yml
+++ b/tests/yaml/config_aggregate8.yml
@@ -1,0 +1,12 @@
+input:
+  grid: "tests/synthetic_model/realization-0/iter-0/cirrus/model/C_FLT_01-0.EGRID"
+  properties:
+    - source: "tests/synthetic_model/realization-0/iter-0/cirrus/model/C_FLT_01-0.INIT"
+      name: "PERMX"
+
+computesettings:
+  weight_by_dz: yes
+  aggregation: sum
+
+output:
+  mapfolder: tmp


### PR DESCRIPTION
We probably support #395, unless there is information missing in the issue?

I have added a test as an example for how this can be used for the specific case "permx * dz".