### PR TITLE
CCS-472: Enable optional export of CO2 mass as 3D grids in UNRST and EGRID files

### DIFF
--- a/src/ccs_scripts/aggregate/_co2_mass.py
+++ b/src/ccs_scripts/aggregate/_co2_mass.py
@@ -1,8 +1,12 @@
+import logging
 from enum import Enum
-from typing import List, Optional
+from pathlib import Path
+from typing import Any
 
 import numpy as np
 import xtgeo
+from resdata.resfile import ResdataFile
+from resfo._unformatted.write import unformatted_write
 
 from ccs_scripts.aggregate._config import CO2MassSettings
 from ccs_scripts.co2_containment.co2_calculation import (
@@ -10,9 +14,12 @@ from ccs_scripts.co2_containment.co2_calculation import (
     Co2DataAtTimeStep,
 )
 from ccs_scripts.co2_containment.source_data import Scenario
+from ccs_scripts.utils.utils import format_error
 from ccs_scripts.utils.xtgeo_logging import setup_xtgeo_logging
 
 setup_xtgeo_logging()
+
+logger = logging.getLogger(__name__)
 
 CO2_MASS_PNAME = "CO2Mass"
 
@@ -33,10 +40,15 @@ def translate_co2data_to_gridproperties(
     co2_data: Co2Data,
     grid_file: str,
     co2_mass_settings: CO2MassSettings,
-    grid: Optional[xtgeo.Grid] = None,
-) -> List[xtgeo.GridProperty]:
+    grid: xtgeo.Grid | None = None,
+    grid_out_dir: str | None = None,
+    date_indices: list[int] | None = None,
+) -> list[xtgeo.GridProperty]:
     """
     Convert CO2 data into in-memory 3D GridProperty objects.
+
+    When ``grid_out_dir`` is set, also write one EGRID/UNRST pair for each
+    selected mass property. The returned properties are unchanged.
     """
     maps = co2_mass_settings.maps
     if maps is None:
@@ -50,7 +62,7 @@ def translate_co2data_to_gridproperties(
         grid = xtgeo.grid_from_file(grid_file)
     property_template = xtgeo.GridProperty(grid)
 
-    out: List[xtgeo.GridProperty] = []
+    out: list[xtgeo.GridProperty] = []
     for co2_at_date in co2_data.data_list:
         tmp_props: dict[MapName, xtgeo.GridProperty] = _convert_to_grid(
             co2_at_date, property_template, co2_data.active_cells
@@ -70,7 +82,166 @@ def translate_co2data_to_gridproperties(
         if (store_all or "free_co2" in maps) and co2_mass_settings.residual_trapping:
             out.append(tmp_props[MapName.MASSFGAS])
             out.append(tmp_props[MapName.MASSTGAS])
+
+    if grid_out_dir is not None:
+        _write_gridproperties(
+            out,
+            grid,
+            grid_file,
+            co2_mass_settings.unrst_source,
+            grid_out_dir,
+            date_indices,
+        )
     return out
+
+
+def _write_gridproperties(
+    properties: list[xtgeo.GridProperty],
+    grid: xtgeo.Grid,
+    grid_file: str,
+    unrst_file: str,
+    grid_out_dir: str,
+    date_indices: list[int] | None,
+) -> None:
+    """Write selected in-memory properties as EGRID/UNRST property series."""
+    output_dir = _prepare_grid_output_directory(grid_out_dir)
+    if date_indices is None:
+        date_indices = list(range(len({prop.date for prop in properties})))
+
+    property_dates = list(dict.fromkeys(prop.date for prop in properties))
+    if len(date_indices) != len(property_dates):
+        raise ValueError(
+            format_error(
+                "Unable to write CO2 mass grid files, problem with UNRST date values"
+            )
+        )
+    source_index_by_date = dict(zip(property_dates, date_indices))
+
+    unrst_data = ResdataFile(unrst_file)
+    grid_data = ResdataFile(grid_file)
+    custom_egrid = _create_custom_egrid_kw(grid_data)
+    grid_active = grid.actnum_array.astype(bool).ravel(order="F")
+
+    grouped_properties: dict[str, list[xtgeo.GridProperty]] = {}
+    for prop in properties:
+        grouped_properties.setdefault(prop.name, []).append(prop)
+
+    for property_name, property_series in grouped_properties.items():
+        restart_keywords: list[tuple[str, Any]] = []
+        keyword_name = MapName(property_name).name
+        for prop in property_series:
+            date_index = source_index_by_date[prop.date]
+            intehead, logihead = _restart_headers_for_grid(
+                unrst_data,
+                date_index,
+                grid,
+            )
+            restart_keywords.extend(
+                [
+                    ("SEQNUM  ", [np.int32(date_index)]),
+                    ("INTEHEAD", intehead),
+                    ("LOGIHEAD", logihead),
+                    (keyword_name, prop.values.data.ravel(order="F")[grid_active]),
+                ]
+            )
+
+        with (output_dir / f"{property_name}.UNRST").open("wb") as stream:
+            unformatted_write(stream, restart_keywords)
+        with (output_dir / f"{property_name}.EGRID").open("wb") as stream:
+            unformatted_write(stream, custom_egrid)
+
+
+def _prepare_grid_output_directory(grid_out_dir: str) -> Path:
+    output_dir = Path(grid_out_dir)
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            raise NotADirectoryError(
+                format_error(f"3D grid output path is not a directory: {output_dir}")
+            )
+        return output_dir
+
+    parent_dir = output_dir.parent
+    if not parent_dir.exists():
+        raise FileNotFoundError(
+            format_error(
+                f"Parent directory for 3D grid output does not exist: {parent_dir}"
+            )
+        )
+    output_dir.mkdir()
+    logger.info("\nCreated new grid folder: %s", output_dir)
+    return output_dir
+
+
+def _create_custom_egrid_kw(grid_data: ResdataFile) -> list[tuple[str, Any]]:
+    """
+    Create the custom list of keywords to export the EGRID file for
+    each co2_mass property
+    """
+    kw_sequence = [
+        "FILEHEAD",
+        "GRIDUNIT",
+        "GDORIENT",
+        "GRIDHEAD",
+        "COORD   ",
+        "ZCORN   ",
+        "ACTNUM  ",
+        "ENDGRID ",
+        "NNCHEAD ",
+        "NNC1    ",
+        "NNC2    ",
+    ]
+    mandatory_kws = [
+        "FILEHEAD",
+        "GRIDUNIT",
+        "GRIDHEAD",
+        "COORD   ",
+        "ZCORN   ",
+        "ENDGRID ",
+    ]
+    custom_egrid = []
+    for kw in kw_sequence:
+        try:
+            val = grid_data[kw.rstrip()][0].numpyView()
+            custom_egrid.append((kw, val))
+        except (AttributeError, ValueError, KeyError):
+            try:
+                val = grid_data[kw.rstrip()][0]
+                custom_egrid.append((kw, val))
+            except KeyError as err:
+                if kw in mandatory_kws:
+                    raise KeyError(
+                        format_error(f"Mandatory key '{kw}' is missing in grid_data")
+                    ) from err
+    return custom_egrid
+
+
+def _restart_headers_for_grid(
+    unrst_data: ResdataFile,
+    date_index: int,
+    grid: xtgeo.Grid,
+) -> tuple[np.ndarray, np.ndarray]:
+    restart_view = unrst_data.restart_view(seqnum_index=date_index)
+    expected_dimensions = (grid.ncol, grid.nrow, grid.nlay)
+    expected_active = int(np.count_nonzero(grid.actnum_array))
+
+    inteheads = restart_view["INTEHEAD"]
+    logiheads = restart_view["LOGIHEAD"]
+
+    for header_index, intehead_kw in enumerate(inteheads):
+        intehead = intehead_kw.numpy_view()
+        nx, ny, nz, active_count = map(int, intehead[8:12])
+        dimensions = (nx, ny, nz)
+
+        if dimensions == expected_dimensions and active_count == expected_active:
+            return intehead, np.array(list(logiheads[header_index]))
+
+    raise ValueError(
+        format_error(
+            "Could not find restart headers matching grid "
+            f"{expected_dimensions} with {expected_active} active cells "
+            f"at restart index {date_index}"
+        )
+    )
 
 
 def _convert_to_grid(

--- a/src/ccs_scripts/aggregate/_co2_mass.py
+++ b/src/ccs_scripts/aggregate/_co2_mass.py
@@ -4,9 +4,8 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import resfo
 import xtgeo
-from resdata.resfile import ResdataFile
-from resfo._unformatted.write import unformatted_write
 
 from ccs_scripts.aggregate._config import CO2MassSettings
 from ccs_scripts.co2_containment.co2_calculation import (
@@ -38,17 +37,16 @@ class MapName(Enum):
 
 def translate_co2data_to_gridproperties(
     co2_data: Co2Data,
-    grid_file: str,
     co2_mass_settings: CO2MassSettings,
-    grid: xtgeo.Grid | None = None,
+    grid: xtgeo.Grid,
     grid_out_dir: str | None = None,
     date_indices: list[int] | None = None,
 ) -> list[xtgeo.GridProperty]:
     """
     Convert CO2 data into in-memory 3D GridProperty objects.
 
-    When ``grid_out_dir`` is set, also write one EGRID/UNRST pair for each
-    selected mass property. The returned properties are unchanged.
+    When ``grid_out_dir`` is set, also write one shared EGRID file and one
+    UNRST file for each selected mass property. The returned properties are unchanged.
     """
     maps = co2_mass_settings.maps
     if maps is None:
@@ -58,8 +56,6 @@ def translate_co2data_to_gridproperties(
     maps = [map_name.lower() for map_name in maps]
 
     store_all = "all" in maps or len(maps) == 0
-    if grid is None:
-        grid = xtgeo.grid_from_file(grid_file)
     property_template = xtgeo.GridProperty(grid)
 
     out: list[xtgeo.GridProperty] = []
@@ -87,7 +83,6 @@ def translate_co2data_to_gridproperties(
         _write_gridproperties(
             out,
             grid,
-            grid_file,
             co2_mass_settings.unrst_source,
             grid_out_dir,
             date_indices,
@@ -98,7 +93,6 @@ def translate_co2data_to_gridproperties(
 def _write_gridproperties(
     properties: list[xtgeo.GridProperty],
     grid: xtgeo.Grid,
-    grid_file: str,
     unrst_file: str,
     grid_out_dir: str,
     date_indices: list[int] | None,
@@ -117,9 +111,7 @@ def _write_gridproperties(
         )
     source_index_by_date = dict(zip(property_dates, date_indices))
 
-    unrst_data = ResdataFile(unrst_file)
-    grid_data = ResdataFile(grid_file)
-    custom_egrid = _create_custom_egrid_kw(grid_data)
+    restart_headers = _restart_headers_for_grid(unrst_file, date_indices, grid)
     grid_active = grid.actnum_array.astype(bool).ravel(order="F")
 
     grouped_properties: dict[str, list[xtgeo.GridProperty]] = {}
@@ -131,11 +123,7 @@ def _write_gridproperties(
         keyword_name = MapName(property_name).name
         for prop in property_series:
             date_index = source_index_by_date[prop.date]
-            intehead, logihead = _restart_headers_for_grid(
-                unrst_data,
-                date_index,
-                grid,
-            )
+            intehead, logihead = restart_headers[date_index]
             restart_keywords.extend(
                 [
                     ("SEQNUM  ", [np.int32(date_index)]),
@@ -145,10 +133,9 @@ def _write_gridproperties(
                 ]
             )
 
-        with (output_dir / f"{property_name}.UNRST").open("wb") as stream:
-            unformatted_write(stream, restart_keywords)
-        with (output_dir / f"{property_name}.EGRID").open("wb") as stream:
-            unformatted_write(stream, custom_egrid)
+        resfo.write(output_dir / f"{property_name}.UNRST", restart_keywords)
+
+    grid.to_file(output_dir / "co2_mass.EGRID", fformat="egrid")
 
 
 def _prepare_grid_output_directory(grid_out_dir: str) -> Path:
@@ -172,76 +159,44 @@ def _prepare_grid_output_directory(grid_out_dir: str) -> Path:
     return output_dir
 
 
-def _create_custom_egrid_kw(grid_data: ResdataFile) -> list[tuple[str, Any]]:
-    """
-    Create the custom list of keywords to export the EGRID file for
-    each co2_mass property
-    """
-    kw_sequence = [
-        "FILEHEAD",
-        "GRIDUNIT",
-        "GDORIENT",
-        "GRIDHEAD",
-        "COORD   ",
-        "ZCORN   ",
-        "ACTNUM  ",
-        "ENDGRID ",
-        "NNCHEAD ",
-        "NNC1    ",
-        "NNC2    ",
-    ]
-    mandatory_kws = [
-        "FILEHEAD",
-        "GRIDUNIT",
-        "GRIDHEAD",
-        "COORD   ",
-        "ZCORN   ",
-        "ENDGRID ",
-    ]
-    custom_egrid = []
-    for kw in kw_sequence:
-        try:
-            val = grid_data[kw.rstrip()][0].numpyView()
-            custom_egrid.append((kw, val))
-        except (AttributeError, ValueError, KeyError):
-            try:
-                val = grid_data[kw.rstrip()][0]
-                custom_egrid.append((kw, val))
-            except KeyError as err:
-                if kw in mandatory_kws:
-                    raise KeyError(
-                        format_error(f"Mandatory key '{kw}' is missing in grid_data")
-                    ) from err
-    return custom_egrid
-
-
 def _restart_headers_for_grid(
-    unrst_data: ResdataFile,
-    date_index: int,
+    unrst_file: str,
+    date_indices: list[int],
     grid: xtgeo.Grid,
-) -> tuple[np.ndarray, np.ndarray]:
-    restart_view = unrst_data.restart_view(seqnum_index=date_index)
+) -> dict[int, tuple[np.ndarray, np.ndarray]]:
     expected_dimensions = (grid.ncol, grid.nrow, grid.nlay)
     expected_active = int(np.count_nonzero(grid.actnum_array))
+    requested_indices = set(date_indices)
+    headers: dict[int, tuple[np.ndarray, np.ndarray]] = {}
+    report_index = -1
+    intehead: np.ndarray | None = None
 
-    inteheads = restart_view["INTEHEAD"]
-    logiheads = restart_view["LOGIHEAD"]
+    for entry in resfo.lazy_read(unrst_file):
+        keyword = entry.read_keyword().strip()
+        if keyword == "SEQNUM":
+            report_index += 1
+            intehead = None
+        elif report_index not in requested_indices:
+            continue
+        elif keyword == "INTEHEAD":
+            intehead = np.asarray(entry.read_array())
+        elif keyword == "LOGIHEAD" and intehead is not None:
+            logihead = np.asarray(entry.read_array())
+            nx, ny, nz, active_count = map(int, intehead[8:12])
+            if (nx, ny, nz) == expected_dimensions and active_count == expected_active:
+                headers[report_index] = (intehead, logihead)
+            intehead = None
 
-    for header_index, intehead_kw in enumerate(inteheads):
-        intehead = intehead_kw.numpy_view()
-        nx, ny, nz, active_count = map(int, intehead[8:12])
-        dimensions = (nx, ny, nz)
-
-        if dimensions == expected_dimensions and active_count == expected_active:
-            return intehead, np.array(list(logiheads[header_index]))
-
-    raise ValueError(
-        format_error(
-            "Could not find restart headers matching grid "
-            f"{expected_dimensions} with {expected_active} active cells "
-            f"at restart index {date_index}"
+    missing_indices = requested_indices - headers.keys()
+    if missing_indices:
+        raise ValueError(
+            format_error(
+                "Could not find restart headers matching grid "
+                f"{expected_dimensions} with {expected_active} active cells "
+                f"at restart indices {sorted(missing_indices)}"
+            )
         )
-    )
+    return headers
 
 
 def _convert_to_grid(

--- a/src/ccs_scripts/aggregate/grid3d_co2_mass_map.py
+++ b/src/ccs_scripts/aggregate/grid3d_co2_mass_map.py
@@ -73,9 +73,8 @@ def generate_co2_mass_maps(config_: RootConfig):
     # Keep 3D properties in memory for aggregation.
     in_memory_properties = translate_co2data_to_gridproperties(
         co2_data,
-        grid_file,
         co2_mass_settings,
-        grid=grid,
+        grid,
         grid_out_dir=config_.output.gridfolder,
         date_indices=date_indices,
     )

--- a/src/ccs_scripts/aggregate/grid3d_co2_mass_map.py
+++ b/src/ccs_scripts/aggregate/grid3d_co2_mass_map.py
@@ -65,14 +65,19 @@ def generate_co2_mass_maps(config_: RootConfig):
     )
 
     dates = config_.input.dates
+    all_dates = [co2_at_date.date for co2_at_date in co2_data.data_list]
+    date_indices = list(range(len(all_dates)))
     if len(dates) > 0:
         co2_data.data_list = [x for x in co2_data.data_list if x.date in dates]
+        date_indices = [index for index, date in enumerate(all_dates) if date in dates]
     # Keep 3D properties in memory for aggregation.
     in_memory_properties = translate_co2data_to_gridproperties(
         co2_data,
         grid_file,
         co2_mass_settings,
         grid=grid,
+        grid_out_dir=config_.output.gridfolder,
+        date_indices=date_indices,
     )
     co2_mass_property_to_map_in_memory(config_, in_memory_properties, grid)
 

--- a/tests/test_co2_mass_maps.py
+++ b/tests/test_co2_mass_maps.py
@@ -160,7 +160,7 @@ def test_co2_mass_map_residual_trapping_cirrus():
     total_co2_file = (
         Path(__file__).absolute().parent
         / "answers"
-        / "mass_maps"
+        / "mass_map"
         / "all--co2_mass_total--23000101.gri"
     )
     assert free_gas_co2_file.exists()

--- a/tests/test_lgr_grids.py
+++ b/tests/test_lgr_grids.py
@@ -92,20 +92,16 @@ def test_mass_maps_with_lgr(lgr_data_dir, lgr_co2_mass_config):
         "co2_mass_gas_phase": "MASS_GAS",
         "co2_mass_total": "MASS_TOT",
     }
-    assert sorted(path.stem for path in grid_output_dir.glob("*.EGRID")) == [
-        "co2_mass_dissolved_water_phase",
-        "co2_mass_gas_phase",
-        "co2_mass_total",
-    ]
+    assert sorted(path.stem for path in grid_output_dir.glob("*.EGRID")) == ["co2_mass"]
     assert sorted(path.stem for path in grid_output_dir.glob("*.UNRST")) == [
         "co2_mass_dissolved_water_phase",
         "co2_mass_gas_phase",
         "co2_mass_total",
     ]
+    egrid = ResdataFile(str(grid_output_dir / "co2_mass.EGRID"))
+    assert len(egrid["GRIDHEAD"]) > 0
     for property_name, keyword in expected_properties.items():
-        egrid = ResdataFile(str(grid_output_dir / f"{property_name}.EGRID"))
         restart = ResdataFile(str(grid_output_dir / f"{property_name}.UNRST"))
-        assert len(egrid["GRIDHEAD"]) > 0
         assert len(restart["SEQNUM"]) == 9
         assert len(restart[keyword]) == 9
 

--- a/tests/test_lgr_grids.py
+++ b/tests/test_lgr_grids.py
@@ -7,6 +7,7 @@ import pandas
 import pytest
 import resfo
 import xtgeo
+from resdata.resfile import ResdataFile
 from resdata.summary import Summary
 
 from ccs_scripts.aggregate import grid3d_aggregate_map, grid3d_co2_mass_map
@@ -80,10 +81,33 @@ def lgr_aggregate_sgas_config(lgr_data_dir, tmp_path):
 
 def test_mass_maps_with_lgr(lgr_data_dir, lgr_co2_mass_config):
     output_dir = Path(lgr_co2_mass_config.output.mapfolder)
+    grid_output_dir = output_dir / "3d"
+    lgr_co2_mass_config.output.gridfolder = str(grid_output_dir)
 
     grid3d_co2_mass_map.generate_co2_mass_maps(lgr_co2_mass_config)
     # 9 time stamps, 3 maps per timestamp:
     assert len(list(Path(output_dir).glob("*.gri"))) == 9 * 3
+    expected_properties = {
+        "co2_mass_dissolved_water_phase": "MASSDISW",
+        "co2_mass_gas_phase": "MASS_GAS",
+        "co2_mass_total": "MASS_TOT",
+    }
+    assert sorted(path.stem for path in grid_output_dir.glob("*.EGRID")) == [
+        "co2_mass_dissolved_water_phase",
+        "co2_mass_gas_phase",
+        "co2_mass_total",
+    ]
+    assert sorted(path.stem for path in grid_output_dir.glob("*.UNRST")) == [
+        "co2_mass_dissolved_water_phase",
+        "co2_mass_gas_phase",
+        "co2_mass_total",
+    ]
+    for property_name, keyword in expected_properties.items():
+        egrid = ResdataFile(str(grid_output_dir / f"{property_name}.EGRID"))
+        restart = ResdataFile(str(grid_output_dir / f"{property_name}.UNRST"))
+        assert len(egrid["GRIDHEAD"]) > 0
+        assert len(restart["SEQNUM"]) == 9
+        assert len(restart[keyword]) == 9
 
     # In this Cirrus model, the following keywords are present:
     # - FSMDS (dissolved)


### PR DESCRIPTION
Solves https://github.com/equinor/ccs-scripts/issues/472

Reimplements the 3D grid writing, depending on argument "gridfolder" being provided, in which case EGRID and UNRST files are produced for CO2 mass.

Calculate 3D maps -> (Optional writing) -> Aggregate maps. The 3D maps are kept in memory between calculation and aggregation, rather than the old write -> reload and aggregate flow.


